### PR TITLE
Use relative base path for production build

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,10 @@ import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
-  base: mode === 'production' ? '/vineyard-ai-guide/' : '/',
+  // Use a relative base path in production so the app can be served from any URL
+  // without broken asset links. This fixes a deployment issue where the site
+  // worked locally but assets were missing in production.
+  base: mode === 'production' ? './' : '/',
   server: {
     host: "::",
     port: 8080,


### PR DESCRIPTION
## Summary
- ensure Vite assets resolve correctly in production

## Testing
- `npm run build`
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a671bbc5f48328a7b25d15c95f469a